### PR TITLE
Webstart build

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -209,6 +209,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.application_server.port": ["APPLICATION_SERVER_PORT", "4080", str],
     "omero.web.static_url": ["STATIC_URL", "/static/", str],
     "omero.web.staticfile_dirs": ["STATICFILES_DIRS", '[]', json.loads],
+    "omero.web.index_template": ["INDEX_TEMPLATE", "webstart/index.html", str],
     "omero.web.caches": ["CACHES", '{}', json.loads],
     "omero.web.webgateway_cache": ["WEBGATEWAY_CACHE", None, leave_none_unset],
     "omero.web.session_engine": ["SESSION_ENGINE", DEFAULT_SESSION_ENGINE, check_session_engine],
@@ -394,6 +395,7 @@ INSTALLED_APPS = (
     'omeroweb.webgateway',
     'omeroweb.webtest',
     'omeroweb.webredirect',
+    'omeroweb.webstart',
     
 )
 

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -36,6 +36,8 @@ handler500 = "omeroweb.feedback.views.handler500"
 # url patterns
 urlpatterns = patterns('',
     
+    url( r'^$', 'omeroweb.webstart.views.index', name="index" ),
+    
     (r'^favicon\.ico$', 'django.views.generic.simple.redirect_to', {'url': '/static/common/image/ome.ico'}),
     
     (r'(?i)^webadmin/', include('omeroweb.webadmin.urls')),
@@ -44,6 +46,8 @@ urlpatterns = patterns('',
     (r'(?i)^webgateway/', include('omeroweb.webgateway.urls')),
     (r'(?i)^webtest/', include('omeroweb.webtest.urls')),    
     (r'(?i)^url/', include('omeroweb.webredirect.urls')),
+    (r'(?i)^webstart/', include('omeroweb.webstart.urls')),
+    
 )
 
 for app in settings.ADDITIONAL_APPS:

--- a/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/index.html
+++ b/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/index.html
@@ -1,0 +1,51 @@
+{% extends "webgateway/core_html.html" %}
+{% load i18n %}
+
+{% comment %}
+<!--
+  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  All rights reserved.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+{% endcomment %}
+
+{% block title %}
+    {% trans "OMERO platform" %}
+{% endblock %}
+
+
+{% block body %}
+
+<div id="login-logo">
+    <img src="{% static "webgateway/img/logo.png" %}" />
+</div>
+
+<div class="bodyWrapper">
+    <div><h1>
+        {% trans "Go to" %}: <a href="{% url waindex %}">{% trans "Webadmin" %}</a>, <a href="{% url webindex %}">{% trans "Webclient" %}</a>
+    </h1>
+    {% block content %}{% endblock %}
+    </div>
+    
+    <script src="http://www.java.com/js/deployJava.js"></script>
+    <script>
+        var url = "{% url webstart_insight %}";
+        deployJava.createWebStartLaunchButton(url, '1.6.0');
+    </script>
+    
+    </div>
+</div>
+
+{% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
+++ b/components/tools/OmeroWeb/omeroweb/webstart/templates/webstart/insight.xml
@@ -1,0 +1,86 @@
+{% comment %}
+<!--
+  Copyright (C) 2011 University of Dundee & Open Microscopy Environment.
+  All rights reserved.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+{% endcomment %}
+
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp codebase="{{ codebase }}" href="{{ href }}">
+  <information>
+    <title>OMERO.insight</title>
+    <vendor>The Open Microscopy Environment</vendor>
+    <homepage href="http://openmicroscopy.org"/>
+    <icon href="{% static 'webgateway/img/logo.png' %}"/>
+    <shortcut online="false">
+      <desktop/>
+    </shortcut>
+    <offline-allowed/>
+  </information>
+  <security>
+      <all-permissions/>
+  </security>
+  <resources>
+    <j2se version="1.5.0+" max-heap-size="512m"/>
+    <jar href="JHotDraw.jar"/>
+    <jar href="TableLayout.jar"/>
+    <jar href="ai_path.jar"/>
+    <jar href="axis.jar"/>
+    <jar href="backport-util-concurrent.jar"/>
+    <jar href="bio-formats.jar"/>
+    <jar href="bufr.jar"/>
+    <jar href="commons-codec.jar"/>
+    <jar href="commons-collections.jar"/>
+    <jar href="commons-digester.jar"/>
+    <jar href="commons-discovery.jar"/>
+    <jar href="commons-httpclient.jar"/>
+    <jar href="commons-io.jar"/>
+    <jar href="commons-lang.jar"/>
+    <jar href="commons-logging.jar"/>
+    <jar href="commons-validator.jar"/>
+    <jar href="ehcache.jar"/>
+    <jar href="gicentreUtils.jar"/>
+    <jar href="gluegen-rt.jar"/>
+    <jar href="grib.jar"/>
+    <jar href="ini4j.jar"/>
+    <jar href="jai_imageio.jar"/>
+    <jar href="jaxrpc.jar"/>
+    <jar href="jcommon.jar"/>
+    <jar href="jfreechart.jar"/>
+    <jar href="jogl.jar"/>
+    <jar href="loci-common.jar"/>
+    <jar href="log4j.jar"/>
+    <jar href="mdbtools-java.jar"/>
+    <!--<jar href="metakit.jar"/>-->
+    <jar href="nanoxml.jar"/>
+    <jar href="netcdf.jar"/>
+    <jar href="ols-client.jar"/>
+    <jar href="ome-xml.jar"/>
+    <jar href="omero.insight.jar"/>
+    <jar href="physics.jar"/>
+    <jar href="poi.jar"/>
+    <jar href="poi-loci.jar"/>
+    <jar href="saaj.jar"/>
+    <jar href="serializer.jar"/>
+    <jar href="slf4j-api.jar"/>
+    <jar href="slf4j-log4j12.jar"/>
+    <jar href="swingx.jar"/>
+    <jar href="wsdl4j.jar"/>
+    <jar href="xalan.jar"/>
+  </resources>
+  <application-desc main-class="org.openmicroscopy.shoola.Main"/>
+</jnlp>
+

--- a/components/tools/OmeroWeb/omeroweb/webstart/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/urls.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# 
+# 
+# 
+# Copyright (c) 2008 University of Dundee. 
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>, 2008.
+# 
+# Version: 1.0
+#
+
+from django.conf.urls.defaults import *
+from omeroweb.webstart import views
+
+urlpatterns = patterns('django.views.generic.simple',
+    url( r'^insight\.jnlp$', views.insight, name='webstart_insight'),
+)

--- a/components/tools/OmeroWeb/omeroweb/webstart/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webstart/views.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# 
+# 
+# 
+# Copyright (c) 2008 University of Dundee. 
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>, 2008.
+# 
+# Version: 1.0
+#
+
+from django.conf import settings
+from django.core import template_loader
+from django.template import RequestContext as Context
+from django.shortcuts import render_to_response
+from django.http import HttpResponse
+from django.core.urlresolvers import reverse
+
+def index(request):
+    template = settings.INDEX_TEMPLATE
+    if template is None or len(template) < 1:
+        template = 'webstart/index.html'
+    return render_to_response(template,None)
+
+def insight(request):
+    t = template_loader.get_template('webstart/insight.xml')
+    context = {'codebase': request.build_absolute_uri(settings.STATIC_URL+'webstart/'), 'href':request.build_absolute_uri(reverse("webstart_insight"))}
+    c = Context(request, context)
+    return HttpResponse(t.render(c), content_type="application/x-java-jnlp-file")


### PR DESCRIPTION
- adding index page
- support for webstart
- launching insight

In order to set it up on development server:

```
bin/omero config set omero.web.staticfile_dirs '[["webstart", "/omero_path/lib/insight"]]'
```

In order to set it up on production server: 

update your Stanza for OMERO.web your Apache/nginx configurations

```
<Directory "/omero_path/lib/insight">
    Options -Indexes FollowSymLinks
    Order allow,deny
    Allow from all
</Directory>

Alias /static/webstart /omero_pat/lib/insight
```

@chris-allan , @will-moore might also be interested in that
