### PR TITLE
Replace file.sha1.val by file.hash.val

### DIFF
--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -915,7 +915,7 @@ class ProcessorI(omero.grid.Processor, omero.util.Servant):
             self.logger.info("Downloaded file: %s" % file.id.val)
             s = client.sha1(str(process.script_path))
             if not s == file.hash.val:
-                msg = "Sha1s don't match! expected %s, found %s" % (file.sha1.val, s)
+                msg = "Sha1s don't match! expected %s, found %s" % (file.hash.val, s)
                 self.logger.error(msg)
                 process.cleanup()
                 raise omero.InternalException(None, None, msg)


### PR DESCRIPTION
Noticed by locally hacking an example and trying to relaunch the script using the previous ID:

```
[hudson-x@ome-ci-c6-03 OMERO5]$ bin/omero -p 14064 script launch 3703 PARAM1=1
/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omeroweb/settings.py:40: DeprecationWarning: django.utils.simplejson is deprecated; use json instead.
  from django.utils import simplejson as json
Using session 95e1290b-e973-4345-8953-62a4e256dd2e (root@localhost:14064). Idle timeout: 10.0 min. Current group: system
Traceback (most recent call last):
  File "bin/omero", line 125, in <module>
    rv = omero.cli.argv()
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/cli.py", line 1195, in argv
    cli.invoke(args[1:])
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/cli.py", line 745, in invoke
    stop = self.onecmd(line, previous_args)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/cli.py", line 814, in onecmd
    self.execute(line, previous_args)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/cli.py", line 894, in execute
    args.func(args)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/plugins/script.py", line 411, in launch
    params = svc.getParams(script_id)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero_api_IScript_ice.py", line 138, in getParams
    return _M_omero.api.IScript._op_getParams.invoke(self, ((scriptID, ), _ctx))
omero.InternalException: exception ::omero::InternalException
{
    serverStackTrace = Traceback (most recent call last):
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/util/decorators.py", line 61, in exc_handler
    rv = func(*args, **kwargs)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/processor.py", line 846, in parseJob
    prx, process = self.process(client, session, job, current, None, properties, iskill)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/util/decorators.py", line 28, in handler
    return func(*args, **kwargs)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero/processor.py", line 918, in process
    msg = "Sha1s don't match! expected %s, found %s" % (file.sha1.val, s)
  File "/homes/hudson-x/OMERO.server-5.0.0-beta2-RC2-209-70ad84f-ice33-b503/lib/python/omero_model_OriginalFileI.py", line 540, in __getattr__
    raise AttributeError("'%s' object has no attribute '%s' or '%s'" % (self.__class__.__name__, getter, questn))
AttributeError: 'OriginalFileI' object has no attribute 'getSha1' or 'isSha1'

    serverExceptionClass = 
    message = Internal exception
}

```
