### PR TITLE
Refactor test_db.py unit tests

### DIFF
--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -19,6 +19,13 @@ from omero_ext.mox import Mox
 import getpass
 import __builtin__
 
+hash_map = {
+    ('0', ''): 'PJueOtwuTPHB8Nq/1rFVxg==',
+    ('0', '--no-salt'): 'vvFwuczAmpyoRC0Nsv8FCw==',
+    ('1', ''): 'pvL5Tyr9tCD2esF938sHEQ==',
+    ('1', '--no-salt'): 'vvFwuczAmpyoRC0Nsv8FCw==',
+}
+
 
 class TestDatabase(object):
 
@@ -95,9 +102,8 @@ class TestDatabase(object):
             self.expectConfirmation("ome", id=user_id)
             self.mox.ReplayAll()
         self.password(args)
-        if no_salt:
-            out, err = capsys.readouterr()
-            assert out.strip() == self.password_output(user_id)
+        out, err = capsys.readouterr()
+        assert out.strip() == self.password_output(user_id, no_salt)
 
     @pytest.mark.parametrize(
         'script_input', ["", "%(version)s", "%(version)s %(patch)s",
@@ -135,10 +141,9 @@ class TestDatabase(object):
         raw_input("Please enter omero.db.patch [%s]: " %
                   self.data["patch"]).AndReturn(patch)
 
-    def password_output(self, user_id):
-        update_msg = "UPDATE password SET hash = 'vvFwuczAmpyoRC0Nsv8FCw=='" \
+    def password_output(self, user_id, no_salt):
+        update_msg = "UPDATE password SET hash = \'%s\'" \
             " WHERE experimenter_id  = %s;"
-        if user_id:
-            return update_msg % user_id
-        else:
-            return update_msg % "0"
+        if not user_id:
+            user_id = "0"
+        return update_msg % (hash_map[(user_id, no_salt)], user_id)

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -4,7 +4,7 @@
 """
    Test of the omero db control.
 
-   Copyright 2009 Glencoe Software, Inc. All rights reserved.
+   Copyright 2009-2013 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -96,32 +96,18 @@ class TestDatabase(object):
         else:
             self.password("ome")
 
-    def testScript(self):
-        self.expectVersion(self.data["version"])
-        self.expectPatch(self.data["patch"])
-        self.expectPassword("ome")
-        self.expectConfirmation("ome")
-        self.mox.ReplayAll()
-        self.script("")
-
-    def testAutomatedScript1(self):
-
-        # This should not be asked for, but ignoring for the moment
-        self.expectVersion(self.data["version"])
-        self.expectPatch(self.data["patch"])
-        self.expectPassword("ome")
-        self.expectConfirmation("ome")
-        self.mox.ReplayAll()
-        self.script("%(version)s")
-
-    def testAutomatedScript2(self):
-        self.expectPassword("ome")
-        self.expectConfirmation("ome")
-        self.mox.ReplayAll()
-        self.script("%(version)s %(patch)s")
-
-    def testAutomatedScript3(self):
-        self.script("%(version)s %(patch)s ome")
+    @pytest.mark.parametrize(
+        'script_input', ["", "%(version)s", "%(version)s %(patch)s",
+                         "%(version)s %(patch)s ome"])
+    def testAutomatedScript(self, script_input):
+        if "version" not in script_input or "patch" not in script_input:
+            self.expectVersion(self.data["version"])
+            self.expectPatch(self.data["patch"])
+        if "ome" not in script_input:
+            self.expectPassword("ome")
+            self.expectConfirmation("ome")
+            self.mox.ReplayAll()
+        self.script(script_input)
 
     def password_ending(self, user, id):
         if id is not None:

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -82,7 +82,7 @@ class TestDatabase(object):
     @pytest.mark.parametrize('no_salt', ['', '--no-salt'])
     @pytest.mark.parametrize('user_id', ['', '0', '1'])
     @pytest.mark.parametrize('password', ['', 'ome'])
-    def testPassword(self, user_id, password, no_salt):
+    def testPassword(self, user_id, password, no_salt, capsys):
         args = ""
         if user_id:
             args += "--user-id=%s " % user_id
@@ -95,6 +95,9 @@ class TestDatabase(object):
             self.expectConfirmation("ome", id=user_id)
             self.mox.ReplayAll()
         self.password(args)
+        if no_salt:
+            out, err = capsys.readouterr()
+            assert out.strip() == self.password_output(user_id)
 
     @pytest.mark.parametrize(
         'script_input', ["", "%(version)s", "%(version)s %(patch)s",
@@ -131,3 +134,11 @@ class TestDatabase(object):
     def expectPatch(self, patch):
         raw_input("Please enter omero.db.patch [%s]: " %
                   self.data["patch"]).AndReturn(patch)
+
+    def password_output(self, user_id):
+        update_msg = "UPDATE password SET hash = 'vvFwuczAmpyoRC0Nsv8FCw=='" \
+            " WHERE experimenter_id  = %s;"
+        if user_id:
+            return update_msg % user_id
+        else:
+            return update_msg % "0"

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -79,12 +79,15 @@ class TestDatabase(object):
         self.mox.ReplayAll()
         self.script("%(version)s %(patch)s")
 
-    @pytest.mark.parametrize('user_id', [None, '0', '1'])
-    @pytest.mark.parametrize('password', [None, 'ome'])
-    def testPassword(self, user_id, password):
+    @pytest.mark.parametrize('no_salt', ['', '--no-salt'])
+    @pytest.mark.parametrize('user_id', ['', '0', '1'])
+    @pytest.mark.parametrize('password', ['', 'ome'])
+    def testPassword(self, user_id, password, no_salt):
         args = ""
         if user_id:
             args += "--user-id=%s " % user_id
+        if no_salt:
+            args += "%s " % no_salt
         if password:
             args += "%s" % password
         else:

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -79,7 +79,7 @@ class TestDatabase(object):
         self.mox.ReplayAll()
         self.script("%(version)s %(patch)s")
 
-    @pytest.mark.parametrize('user_id', [None, '1'])
+    @pytest.mark.parametrize('user_id', [None, '0', '1'])
     @pytest.mark.parametrize('password', [None, 'ome'])
     def testPassword(self, user_id, password):
         args = ""
@@ -107,7 +107,7 @@ class TestDatabase(object):
         self.script(script_input)
 
     def password_ending(self, user, id):
-        if id is not None:
+        if id and id != '0':
             rv = "user %s: " % id
         else:
             rv = "%s user: " % user

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -102,7 +102,7 @@ class TestDatabase(object):
     @pytest.mark.parametrize(
         'script_input', ["", "%(version)s", "%(version)s %(patch)s",
                          "%(version)s %(patch)s ome"])
-    def testAutomatedScript(self, script_input):
+    def testScript(self, script_input):
         if "version" not in script_input or "patch" not in script_input:
             self.expectVersion(self.data["version"])
             self.expectPatch(self.data["patch"])

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -61,7 +61,6 @@ class TestDatabase(object):
         self.cli.invoke("db password " + string % self.data, strict=strict)
 
     def testBadVersionDies(self):
-        self.mox.ReplayAll()
         with pytest.raises(NonZeroReturnCode):
             self.script("NONE NONE pw")
 
@@ -80,23 +79,22 @@ class TestDatabase(object):
         self.mox.ReplayAll()
         self.script("%(version)s %(patch)s")
 
-    def testPassword(self):
-        self.expectPassword("ome")
-        self.expectConfirmation("ome")
+    @pytest.mark.parametrize('id', [None, '1'])
+    def testPassword(self, id):
+        self.expectPassword("ome", id=id)
+        self.expectConfirmation("ome", id=id)
         self.mox.ReplayAll()
-        self.password("")
+        if id:
+            self.password("--user-id=%s" % id)
+        else:
+            self.password("")
 
-    def testAutomatedPassword(self):
-        self.password("ome")
-
-    def testUserPassword(self):
-        self.expectPassword("ome", id="1")
-        self.expectConfirmation("ome", id="1")
-        self.mox.ReplayAll()
-        self.password("--user-id=1")
-
-    def testAutomatedUserPassword(self):
-        self.password("--user-id=1 ome")
+    @pytest.mark.parametrize('id', [None, '1'])
+    def testAutomatedPassword(self, id):
+        if id:
+            self.password("ome --user-id=%s" % id)
+        else:
+            self.password("ome")
 
     def testScript(self):
         self.expectVersion(self.data["version"])

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -79,22 +79,19 @@ class TestDatabase(object):
         self.mox.ReplayAll()
         self.script("%(version)s %(patch)s")
 
-    @pytest.mark.parametrize('id', [None, '1'])
-    def testPassword(self, id):
-        self.expectPassword("ome", id=id)
-        self.expectConfirmation("ome", id=id)
-        self.mox.ReplayAll()
-        if id:
-            self.password("--user-id=%s" % id)
+    @pytest.mark.parametrize('user_id', [None, '1'])
+    @pytest.mark.parametrize('password', [None, 'ome'])
+    def testPassword(self, user_id, password):
+        args = ""
+        if user_id:
+            args += "--user-id=%s " % user_id
+        if password:
+            args += "%s" % password
         else:
-            self.password("")
-
-    @pytest.mark.parametrize('id', [None, '1'])
-    def testAutomatedPassword(self, id):
-        if id:
-            self.password("ome --user-id=%s" % id)
-        else:
-            self.password("ome")
+            self.expectPassword("ome", id=user_id)
+            self.expectConfirmation("ome", id=user_id)
+            self.mox.ReplayAll()
+        self.password(args)
 
     @pytest.mark.parametrize(
         'script_input', ["", "%(version)s", "%(version)s %(patch)s",

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -14,13 +14,16 @@ from path import path
 from omero.plugins.db import DatabaseControl
 from omero.util.temp_files import create_path
 from omero.cli import NonZeroReturnCode
-from mocks import MockCLI
+from omero.cli import CLI
+from omero_ext.mox import Mox
+import getpass
+import __builtin__
 
 
 class TestDatabase(object):
 
     def setup_method(self, method):
-        self.cli = MockCLI()
+        self.cli = CLI()
         self.cli.register("db", DatabaseControl, "TEST")
 
         dir = path(__file__) / ".." / ".." / ".." / ".." / ".." / ".." /\
@@ -40,38 +43,47 @@ class TestDatabase(object):
 
         self.file = create_path()
 
+        self.mox = Mox()
+        self.mox.StubOutWithMock(getpass, 'getpass')
+        self.mox.StubOutWithMock(__builtin__, "raw_input")
+
     def teardown_method(self, method):
         self.file.remove()
+        self.mox.UnsetStubs()
+        self.mox.VerifyAll()
 
     def script(self, string, strict=True):
         string = string % self.data
-        self.cli.invoke("db script -f %s %s" % (self.file, string),
+        self.cli.invoke("db script -f %s %s" % (str(self.file), string),
                         strict=strict)
 
     def password(self, string, strict=True):
         self.cli.invoke("db password " + string % self.data, strict=strict)
 
     def testBadVersionDies(self):
-        self.expectPassword("pw")
-        self.expectConfirmation("pw")
-        pytest.raises(NonZeroReturnCode, self.script, "NONE NONE pw")
+        self.mox.ReplayAll()
+        with pytest.raises(NonZeroReturnCode):
+            self.script("NONE NONE pw")
 
     def testPasswordIsAskedForAgainIfDiffer(self):
         self.expectPassword("ome")
         self.expectConfirmation("bad")
         self.expectPassword("ome")
         self.expectConfirmation("ome")
+        self.mox.ReplayAll()
         self.script("'' ''")
 
     def testPasswordIsAskedForAgainIfEmpty(self):
         self.expectPassword("")
         self.expectPassword("ome")
         self.expectConfirmation("ome")
+        self.mox.ReplayAll()
         self.script("%(version)s %(patch)s")
 
     def testPassword(self):
         self.expectPassword("ome")
         self.expectConfirmation("ome")
+        self.mox.ReplayAll()
         self.password("")
 
     def testAutomatedPassword(self):
@@ -80,6 +92,7 @@ class TestDatabase(object):
     def testUserPassword(self):
         self.expectPassword("ome", id="1")
         self.expectConfirmation("ome", id="1")
+        self.mox.ReplayAll()
         self.password("--user-id=1")
 
     def testAutomatedUserPassword(self):
@@ -90,21 +103,23 @@ class TestDatabase(object):
         self.expectPatch(self.data["patch"])
         self.expectPassword("ome")
         self.expectConfirmation("ome")
+        self.mox.ReplayAll()
         self.script("")
 
     def testAutomatedScript1(self):
 
         # This should not be asked for, but ignoring for the moment
         self.expectVersion(self.data["version"])
-
         self.expectPatch(self.data["patch"])
         self.expectPassword("ome")
         self.expectConfirmation("ome")
+        self.mox.ReplayAll()
         self.script("%(version)s")
 
     def testAutomatedScript2(self):
         self.expectPassword("ome")
         self.expectConfirmation("ome")
+        self.mox.ReplayAll()
         self.script("%(version)s %(patch)s")
 
     def testAutomatedScript3(self):
@@ -118,17 +133,17 @@ class TestDatabase(object):
         return "password for OMERO " + rv
 
     def expectPassword(self, pw, user="root", id=None):
-        self.cli.expect("Please enter %s" %
-                        self.password_ending(user, id), pw)
+        getpass.getpass("Please enter %s" %
+                        self.password_ending(user, id)).AndReturn(pw)
 
     def expectConfirmation(self, pw, user="root", id=None):
-        self.cli.expect("Please re-enter %s" %
-                        self.password_ending(user, id), pw)
+        getpass.getpass("Please re-enter %s" %
+                        self.password_ending(user, id)).AndReturn(pw)
 
     def expectVersion(self, version):
-        self.cli.expect("Please enter omero.db.version [%s]: " %
-                        self.data["version"], version)
+        raw_input("Please enter omero.db.version [%s]: " %
+                  self.data["version"]).AndReturn(version)
 
     def expectPatch(self, patch):
-        self.cli.expect("Please enter omero.db.patch [%s]: " %
-                        self.data["patch"], patch)
+        raw_input("Please enter omero.db.patch [%s]: " %
+                  self.data["patch"]).AndReturn(patch)


### PR DESCRIPTION
- Use `CLI` with `mox` stubs instead of `MockCLI`
- Parametrize tests to test all combinations and group tests
- Test `--no-salt` arguments
- For `bin/omero db password --no-salt`, test the CLI output using `cap sys`

Couple of open questions:
- should/can we test `bin/omero db password --user-id xx` without `--no-salt`?
- is there a way to test `bin/omero db script --no-salt` ?
