### PR TITLE
Fix population of MapAnnotation.Value

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -4874,10 +4874,9 @@ public class OMEROMetadataStoreClient
 
     public void setMapAnnotationValue(Map<String, String> value, int mapAnnotationIndex) {
         final MapAnnotation o = getMapAnnotation(mapAnnotationIndex);
-        if (o == null || o.getMapValue() == null) {
-            o.setMapValue(null);
-        } else {
-            final Map<String, RString> stringRStringMap = new HashMap<String, RString>(o.getMapValue().size());
+        if (o != null) {
+            final Map<String, RString> stringRStringMap = new HashMap<String, RString>();
+
             for (final Entry<String, String> mapEntry : value.entrySet()) {
                 stringRStringMap.put(mapEntry.getKey(), toRType(mapEntry.getValue()));
             }


### PR DESCRIPTION
The previous logic for setMapAnnotationValue was a no-op unless the
Value had already been set to non-null.  Now, as long as the
MapAnnotation object at the specified index is non-null (i.e.
setMapAnnotationID(...) has been called), the Value attribute will be
set.
