### PR TITLE
12145 rnd settings

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -8387,4 +8387,28 @@ class OMEROGateway
         }
         return new HashMap();
     }
+
+    /**
+     * Retrieves the rendering settings for the specified pixels set.
+     *
+     * @param ctx The security context.
+     * @param rndID The rendering settings ID.
+     * @return See above.
+     * @throws DSOutOfServiceException If the connection is broken, or logged
+     *                                 in.
+     * @throws DSAccessException       If an error occurred while trying to
+     *                                 retrieve data from OMEDS service.
+     */
+    RenderingDef getRenderingDef(SecurityContext ctx, long rndID)
+        throws DSOutOfServiceException, DSAccessException
+    {
+        Connector c = getConnector(ctx, true, false);
+        try {
+            IPixelsPrx service = c.getPixelsService();
+            return service.loadRndSettings(rndID);
+        } catch (Exception e) {
+            handleException(e, "Cannot retrieve the rendering settings");
+        }
+        return null;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.data.OmeroImageService
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -40,7 +40,6 @@ import com.sun.opengl.util.texture.TextureData;
 import omero.api.ThumbnailStorePrx;
 //Application-internal dependencies
 import omero.constants.projection.ProjectionType;
-import omero.model.RenderingDef;
 import omero.romio.PlaneDef;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
@@ -68,9 +67,6 @@ import pojos.WorkflowData;
  * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
- * <small>
- * (<b>Internal version:</b> $Revision: $ $Date: $)
- * </small>
  * @since OME2.2
  */
 public interface OmeroImageService

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageService.java
@@ -898,4 +898,17 @@ public interface OmeroImageService
 	Long getRenderingDef(SecurityContext ctx, long pixelsID, long userID)
 		throws DSOutOfServiceException, DSAccessException;
 
+    /**
+     * Retrieves the rendering settings for the specified pixels set.
+     *
+     * @param ctx The security context.
+     * @param rndID  The rendering settings ID.
+     * @return See above.
+     * @throws DSOutOfServiceException If the connection is broken, or logged
+     *                                 in.
+     * @throws DSAccessException       If an error occurred while trying to
+     *                                 retrieve data from OMEDS service.
+     */
+	RndProxyDef getSettings(SecurityContext ctx, long rndID)
+        throws DSOutOfServiceException, DSAccessException;
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1906,4 +1906,17 @@ class OmeroImageServiceImpl
 		return def.getId().getValue();
 	}
 
+	/**
+	 * Implemented as specified by {@link OmeroDataService}.
+	 * @see OmeroImageService#getRenderingDef(SecurityContext, long)
+	 */
+	public RndProxyDef getSettings(SecurityContext ctx, long rndID)
+        throws DSOutOfServiceException, DSAccessException
+    {
+	    if (rndID < 0) return null;
+	    RenderingDef def = gateway.getRenderingDef(ctx, rndID);
+        if (def == null) return null;
+        return PixelsServicesFactory.convert(def);
+    }
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.data.OmeroImageServiceImpl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -122,10 +122,6 @@ import pojos.WorkflowData;
 * 				<a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
 * @author	Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
 * 	<a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
-* @version 3.0
-* <small>
-* (<b>Internal version:</b> $Revision: $ $Date: $)
-* </small>
 * @since OME3.0
 */
 class OmeroImageServiceImpl

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.rnd.RenderingControlFactory
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -75,10 +75,6 @@ import pojos.PixelsData;
 * 				<a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
 * @author	Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
 * 				<a href="mailto:a.falconi@dundee.ac.uk">a.falconi@dundee.ac.uk</a>
-* @version 3.0
-* <small>
-* (<b>Internal version:</b> $Revision: $ $Date: $)
-* </small>
 * @since OME2.2
 */
 public class PixelsServicesFactory

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
@@ -146,7 +146,8 @@ public class PixelsServicesFactory
 	{
 		if (rndDef == null) return null;
 		
-		RndProxyDef proxy = new RndProxyDef();
+		RndProxyDef proxy = new RndProxyDef(rndDef.getId().getValue(),
+		        rndDef.getDetails().getOwner().getId().getValue());
 		try {
 			long v = rndDef.getDetails().getUpdateEvent().getTime().getValue();
 			proxy.setLastModified(new Timestamp(v));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
@@ -146,8 +146,7 @@ public class PixelsServicesFactory
 	{
 		if (rndDef == null) return null;
 		
-		RndProxyDef proxy = new RndProxyDef(rndDef.getId().getValue(),
-		        rndDef.getDetails().getOwner().getId().getValue());
+		RndProxyDef proxy = new RndProxyDef(rndDef);
 		try {
 			long v = rndDef.getDetails().getUpdateEvent().getTime().getValue();
 			proxy.setLastModified(new Timestamp(v));

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.rnd.RenderingControlProxy
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RenderingControlProxy.java
@@ -1430,7 +1430,7 @@ class RenderingControlProxy
     	    } else {
     	        long id = servant.saveAsNewSettings();
     	        rndDef = context.getImageService().getSettings(ctx, id);
-    	        return rndDef;
+    	        return rndDef.copy();
     	    }
     		
 		} catch (Throwable e) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.rnd.RndProxyDef
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import omero.model.RenderingDef;
+
 //Third-party libraries
 
 //Application-internal dependencies
@@ -89,21 +91,17 @@ public class RndProxyDef
     /** The name associated to the rendering settings. */
     private String name;
 
-    /** The identifier of the rendering settings.*/
-    private long id;
+    /** The original object.*/
+    private RenderingDef data;
 
-    /** The owner's identifier of the rendering settings.*/
-    private long ownerID;
-
-    /** Creates a new instance.
-     * 
-     * @param id The identifier of the rendering settings.
-     * @param ownerID The owner's identifier of the rendering settings.
+    /**
+     * Creates a new instance.
+     *
+     * @param data The original object
      * */
-    RndProxyDef(long id, long ownerID)
+    RndProxyDef(RenderingDef data)
     {
-        this.id = id;
-        this.ownerID = ownerID;
+        this.data = data;
         compression = 1.0;
         channels = new HashMap<Integer, ChannelBindingsProxy>();
         name = "";
@@ -275,7 +273,7 @@ public class RndProxyDef
      */
     RndProxyDef copy()
     {
-        RndProxyDef copy = new RndProxyDef(this.id, this.ownerID);
+        RndProxyDef copy = new RndProxyDef(this.data);
         copy.setLastModified(this.getLastModified());
         copy.setCompression(this.getCompression());
         copy.setTypeSigned(this.isTypeSigned());
@@ -333,6 +331,16 @@ public class RndProxyDef
      *
      * @return See above.
      */
-    public long getOwnerID() { return ownerID; }
+    public long getOwnerID()
+    {
+        return data.getDetails().getOwner().getId().getValue();
+    }
+
+    /**
+     * Returns the data hosted by this class.
+     *
+     * @return See above.
+     */
+    RenderingDef getData() { return data; }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/RndProxyDef.java
@@ -86,12 +86,24 @@ public class RndProxyDef
     /** Indicates when the settings was last modified. */
     private Timestamp lastModified;
 
-    /** The name associated to the rendering def. */
+    /** The name associated to the rendering settings. */
     private String name;
 
-    /** Creates a new instance. */
-    RndProxyDef()
+    /** The identifier of the rendering settings.*/
+    private long id;
+
+    /** The owner's identifier of the rendering settings.*/
+    private long ownerID;
+
+    /** Creates a new instance.
+     * 
+     * @param id The identifier of the rendering settings.
+     * @param ownerID The owner's identifier of the rendering settings.
+     * */
+    RndProxyDef(long id, long ownerID)
     {
+        this.id = id;
+        this.ownerID = ownerID;
         compression = 1.0;
         channels = new HashMap<Integer, ChannelBindingsProxy>();
         name = "";
@@ -263,7 +275,7 @@ public class RndProxyDef
      */
     RndProxyDef copy()
     {
-        RndProxyDef copy = new RndProxyDef();
+        RndProxyDef copy = new RndProxyDef(this.id, this.ownerID);
         copy.setLastModified(this.getLastModified());
         copy.setCompression(this.getCompression());
         copy.setTypeSigned(this.isTypeSigned());
@@ -315,5 +327,12 @@ public class RndProxyDef
      * @return See above.
      */
     public Timestamp getLastModified() { return lastModified; }
+
+    /** 
+     * Returns the owner's identifier of the rendering settings.
+     *
+     * @return See above.
+     */
+    public long getOwnerID() { return ownerID; }
 
 }

--- a/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullRenderingService.java
+++ b/components/insight/TEST/org/openmicroscopy/shoola/env/data/NullRenderingService.java
@@ -565,4 +565,11 @@ public class NullRenderingService
 		return null;
 	}
 
+    @Override
+    public RndProxyDef getSettings(SecurityContext ctx, long rndID)
+            throws DSOutOfServiceException, DSAccessException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
 }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -854,9 +854,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
             if (saveAs) {
                 loadRenderingDef(id);
                 getThumbnail(id);
+                
             } else {
-
-
                 rendDefObj = retrieveRndSettings(pixelsObj.getId());
 
                 // Unload the linked pixels set to avoid transactional headaches on
@@ -868,8 +867,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
                 // cause IllegalStateExceptions if we're not careful. To compensate
                 // we will now reload the renderer.
                 // *** Ticket #848 -- Chris Allan <callan@blackcat.ca> ***
-                load();
             }
+            load();
             return id;
         } finally {
             rwl.writeLock().unlock();

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -806,10 +806,23 @@ public class ThumbnailBean extends AbstractLevel2Service
             // the rendering settings. FIXME: This should be
             // implemented using IUpdate.touch() or similar once that
             // functionality exists.
-            thumbnailMetadata.setVersion(thumbnailMetadata.getVersion() + 1);
-            Pixels unloadedPixels = new Pixels(pixels.getId(), false);
-            thumbnailMetadata.setPixels(unloadedPixels);
-            dirtyMetadata = true;
+            
+            //Check first if the thumbnail is the one of the settings owner
+            Long ownerId = thumbnailMetadata.getDetails().getOwner().getId();
+            Long rndOwnerId = settings.getDetails().getOwner().getId();
+            if (rndOwnerId.equals(ownerId)) {
+                thumbnailMetadata.setVersion(thumbnailMetadata.getVersion() + 1);
+                Pixels unloadedPixels = new Pixels(pixels.getId(), false);
+                thumbnailMetadata.setPixels(unloadedPixels);
+                dirtyMetadata = true;
+            } else {
+                //new one for owner of the settings.
+                Dimension d = new Dimension(thumbnailMetadata.getSizeX(),
+                        thumbnailMetadata.getSizeY());
+                thumbnailMetadata = ctx.createThumbnailMetadata(pixels, d);
+                thumbnailMetadata = iUpdate.saveAndReturnObject(thumbnailMetadata);
+                dirtyMetadata = false;
+            }
         }
         // dirtyMetadata is left false here because we may be creating a
         // thumbnail for the first time and the Thumbnail object has just been

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -550,7 +550,7 @@ public class ThumbnailCtx
             else if (thumbnailExists && !isMyMetadata)
             {
                 //we need thumbnail for new settings
-                if (userId != metadataOwnerId) {
+                if (sessionUserId == userId && userId != metadataOwnerId) {
                    return false;
                 }
                 log.warn(String.format(

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -549,9 +549,13 @@ public class ThumbnailCtx
             }
             else if (thumbnailExists && !isMyMetadata)
             {
+                //we need thumbnail for new settings
+                if (userId != metadataOwnerId) {
+                   return false;
+                }
                 log.warn(String.format(
                         "Thumbnail metadata is dirty for Pixels Id:%d and " +
-                        "the metadata is owned User id:%d which is not us " +
+                        "the metadata is owned User id:%d which is not " +
                         "User id:%d. Ignoring this and returning the cached " +
                         "thumbnail.", pixelsId, metadataOwnerId, sessionUserId));
                 return true;


### PR DESCRIPTION
this PR:
- Modify the code to either use the `saveCurrentSettings` method or the `saveNewSettings` method depending on rendering settings ownership.
- Fix the `RenderingBean` so that the rendering engine is not null after `saveNewSettings`
- Generate thumbnail if none available when rendering settings are created for the owner of the settings (currently session owner too)
