### PR TITLE
Add client_dir argument and refactor test_import.py

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -81,6 +81,11 @@ class ImportControl(BaseControl):
         parser.add_argument(
             "---errs", nargs="?",
             help="File for storing the standard err of the Java process")
+        parser.add_argument(
+            "--clientdir", type="str",
+            help="Path the the directory containing the client JARs. "
+            " Default: lib/client")
+
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(
             'Naming arguments', 'Optional arguments passed strictly to Java.')
@@ -158,7 +163,10 @@ class ImportControl(BaseControl):
 
     def importer(self, args):
 
-        client_dir = self.ctx.dir / "lib" / "client"
+        if args.clientdir:
+            client_dir = args.clientdir
+        else:
+            client_dir = self.ctx.dir / "lib" / "client"
         etc_dir = self.ctx.dir / "etc"
         xml_file = etc_dir / "logback-cli.xml"
         logback = "-Dlogback.configurationFile=%s" % xml_file

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -82,7 +82,7 @@ class ImportControl(BaseControl):
             "---errs", nargs="?",
             help="File for storing the standard err of the Java process")
         parser.add_argument(
-            "--clientdir", type="str",
+            "--clientdir", type=str,
             help="Path the the directory containing the client JARs. "
             " Default: lib/client")
 


### PR DESCRIPTION
This PR:
- adds an extra `--clientdir` argument to `bin/omero import` allowing to control the client dir (defaulting to `self.ctx.dir`/`lib`/`client`). Apart from allowing to use `cli.invoke()` in the OmeroPy integration tests, @joshmoore pointing out this feature may have other usages when using the CLI with e.g. an upgrade version of Bio-Formats /cc @ximenesuk
- converts `test_import.py` to use `cli.invoke()` (using `--clientdir`). Goals are:
  - to minimize interference with the `library.py` logic
  - to handle the `stderr/stdout` of the `import` command directly in the tests via `capfd` 
  - to simplify the object retrieval logic by parsing the stderr

NB: running these tests show that https://github.com/openmicroscopy/openmicroscopy/pull/2479 disrupts the usage of the `name/description` argument by prepending them with a `=` character.
