### PR TITLE
12145 rnd settings

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/view/MetadataViewerUI.java
@@ -282,7 +282,9 @@ class MetadataViewerUI
         }
         
         viewedByMenu.add(thumbnailsMenuItem);
-		viewedByMenu.show(source, location.x, location.y);
+		if (source != null && source.isVisible()) {
+		    viewedByMenu.show(source, location.x, location.y);
+		}
 	}
 	
 	/** Displays all the thumbnails. */

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7559,6 +7559,23 @@ class _ImageWrapper (BlitzObjectWrapper):
         self._re.saveCurrentSettings(ctx)
         return True
 
+    @assert_re()
+    def resetDefaults(self):
+        if not self.canAnnotate():
+            return False
+        ns = self._conn.CONFIG.IMG_ROPTSNS
+        if ns:
+            opts = self._collectRenderOptions()
+            self.removeAnnotations(ns)
+            ann = omero.gateway.CommentAnnotationWrapper()
+            ann.setNs(ns)
+            ann.setValue('&'.join(['='.join(map(str, x)) for x in opts.items()]))
+            self.linkAnnotation(ann)
+        ctx = self._conn.SERVICE_OPTS.copy()
+        ctx.setOmeroGroup(self.details.group.id.val)
+        self._re.resetDefaults(ctx)
+        return True
+
     def countArchivedFiles (self):
         """
         Returns the number of Original 'archived' Files linked to primary pixels.

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5969,8 +5969,8 @@ class _ImageWrapper (BlitzObjectWrapper):
         ctx = self._conn.SERVICE_OPTS.copy()
 
         ctx.setOmeroGroup(self.details.group.id.val)
-        if self._conn.canBeAdmin():
-            ctx.setOmeroUser(self.details.owner.id.val)
+        #if self._conn.canBeAdmin():
+        #    ctx.setOmeroUser(self.details.owner.id.val)
         re.lookupPixels(pid, ctx)
         if rdid is None:
             rdid = self._getRDef()

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1639,8 +1639,8 @@ def copy_image_rdef_json (request, conn=None, **kwargs):
 @jsonp
 def reset_image_rdef_json (request, iid, conn=None, **kwargs):
     """
-    Try to remove all rendering defs the logged in user has for this image.
-
+    Reset rendering defs default for this image. Do not delete other related settings.
+    
     @param request:     http request
     @param iid:         Image ID
     @param conn:        L{omero.gateway.BlitzGateway}
@@ -1649,7 +1649,7 @@ def reset_image_rdef_json (request, iid, conn=None, **kwargs):
 
     img = conn.getObject("Image", iid)
 
-    if img is not None and img.resetRDefs():
+    if img is not None and img.resetDefaults():
         user_id = conn.getEventContext().userId
         server_id = request.session['connector'].server_id
         webgateway_cache.invalidateObject(server_id, user_id, img)


### PR DESCRIPTION
- Fix exception in insight when using view by button see gh-2365
- Do not always set owner settings when starting rendering engine as admin see gh-2365
- Fix error when clicking on Reset in Web. All rendering settings were deleted, including the settings of other users.
