### PR TITLE
Integration tests for group sudo

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -113,15 +113,16 @@ class TestSessions(CLITest):
         owner = self.new_user(group1, owner=True)  # Owner of first group
         admin = self.new_user(system=True)  # System administrator
 
-        # Administrator are in the list of sudoers
+        # Administrator is in the list of sudoers
         self.check_sudoer(user, admin)
         self.check_sudoer(user, admin, group1)
         self.check_sudoer(user, admin, group2)
 
         # Group owner is in the list of sudoers
         self.check_sudoer(user, owner)
-        self.check_sudoer(user, admin, group1)
-        self.check_sudoer(user, admin, group2)
+        self.check_sudoer(user, owner, group1)
+        with pytest.raises(NonZeroReturnCode):
+            self.check_sudoer(user, owner, group2)
 
         # Other group members are not sudoers
         with pytest.raises(NonZeroReturnCode):

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -107,9 +107,8 @@ class TestSessions(CLITest):
 
         group1 = self.new_group(perms=perms)
         group2 = self.new_group(perms=perms)
-        admin = self.root.sf.getAdminService()
         user = self.new_user(group1, owner=False)  # Member of two groups
-        admin.addGroups(user, [group2])
+        self.root.sf.getAdminService().addGroups(user, [group2])
         member = self.new_user(group1, owner=False)  # Member of first gourp
         owner = self.new_user(group1, owner=True)  # Owner of first group
         admin = self.new_user(system=True)  # System administrator

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -47,7 +47,7 @@ class TestSessions(CLITest):
 
     def check_sudoer(self, target_user, sudoer, group=None):
         self.set_login_args(target_user)
-        self.args += ["--sudo", sudoer.omeName.val]
+        self.args += ["-C", "--sudo", sudoer.omeName.val]
         self.args += ["-w", sudoer.omeName.val]
         if group:
             self.args += ["-g", group.name.val]

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -94,9 +94,15 @@ class TestSessions(CLITest):
         ec = self.cli.get_event_context()
         assert ec.userName == user.omeName.val
 
-    def testLoginAsGroupAdmin(self):
+    def testLoginAs(self):
+
+        group1 = self.new_group()
+        group2 = self.new_group([user])
+        user = self.new_user(group=group1)
+
+
         group = self.new_group()
-        grp_admin = self.new_user(group=group, admin=True)
+        grp_admin = self.new_user(group=group, owner=True)
         admin = grp_admin.omeName.val
         user = self.new_user(group=group)
         self.set_login_args(user)

--- a/components/tools/OmeroPy/test/integration/cmdtest/test_columbus.py
+++ b/components/tools/OmeroPy/test/integration/cmdtest/test_columbus.py
@@ -53,15 +53,15 @@ class TestColumbus(lib.ITest):
     def userconfig(self, perms="rwr---"):
         self.group_a = self.new_group(perms=perms)
         self.client_A, self.user_A = \
-            self.new_client_and_user(group=self.group_a, admin=True)
+            self.new_client_and_user(group=self.group_a, owner=True)
         self.client_B, self.user_B = \
-            self.new_client_and_user(group=self.group_a, admin=False)
+            self.new_client_and_user(group=self.group_a, owner=False)
 
         self.group_b = self.new_group(perms=perms)
         self.client_C, self.user_C = \
-            self.new_client_and_user(group=self.group_b, admin=True)
+            self.new_client_and_user(group=self.group_b, owner=True)
         self.client_D, self.user_D = \
-            self.new_client_and_user(group=self.group_b, admin=False)
+            self.new_client_and_user(group=self.group_b, owner=False)
 
         self.group_c = self.new_group(perms=perms)
         self.client_E, self.user_E = \

--- a/components/tools/OmeroPy/test/integration/library.py
+++ b/components/tools/OmeroPy/test/integration/library.py
@@ -432,10 +432,10 @@ class ITest(object):
         return callback
 
     def new_user(self, group=None, perms=None,
-                 admin=False, system=False):
+                 owner=False, system=False):
         """
-        admin: If user is to be an admin of the created group
-        system: If user is to be a system admin
+        :owner: If user is to be an owner of the created group
+        :system: If user is to be a system admin
         """
 
         if not self.root:
@@ -462,7 +462,7 @@ class ITest(object):
         uid = adminService.createExperimenterWithPassword(
             e, rstring(name), g, listOfGroups)
         e = adminService.lookupExperimenter(name)
-        if admin:
+        if owner:
             adminService.setGroupOwner(g, e)
         if system:
             adminService.addGroups(e, [ExperimenterGroupI(0, False)])
@@ -470,7 +470,7 @@ class ITest(object):
         return adminService.getExperimenter(uid)
 
     def new_client(self, group=None, user=None, perms=None,
-                   admin=False, system=False, session=None, password=None):
+                   owner=False, system=False, session=None, password=None):
         """
         Like new_user() but returns an active client.
 
@@ -489,7 +489,7 @@ class ITest(object):
             if user is not None:
                 user, name = self.user_and_name(user)
             else:
-                user = self.new_user(group, perms, admin, system=system)
+                user = self.new_user(group, perms, owner=owner, system=system)
             props["omero.user"] = user.omeName.val
             if password is not None:
                 props["omero.pass"] = password
@@ -503,10 +503,10 @@ class ITest(object):
         return client
 
     def new_client_and_user(self, group=None, perms=None,
-                            admin=False, system=False):
-        user = self.new_user(group, admin=admin, system=system, perms=perms)
+                            owner=False, system=False):
+        user = self.new_user(group, owner=owner, system=system, perms=perms)
         client = self.new_client(
-            group, user, perms=perms, admin=admin, system=system)
+            group, user, perms=perms, owner=owner, system=system)
         return client, user
 
     def timeit(self, func, *args, **kwargs):

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -49,7 +49,7 @@ class AnnotationPermissions(lib.ITest):
         # create group and users
         self.group = self.new_group(perms=perms)
         self.exps = {}
-        self.exps["owner"] = self.new_user(group=self.group, admin=True)
+        self.exps["owner"] = self.new_user(group=self.group, owner=True)
         self.exps["member1"] = self.new_user(group=self.group)
         self.exps["member2"] = self.new_user(group=self.group)
         self.exps["admin"] = self.new_user(group=self.group, system=True)

--- a/components/tools/OmeroPy/test/integration/test_chmod.py
+++ b/components/tools/OmeroPy/test/integration/test_chmod.py
@@ -37,8 +37,8 @@ class BaseChmodTest(lib.ITest):
 
     def init(self, from_perms, to_perms):
         self.group = self.new_group(perms=from_perms)
-        self.owner = self.new_client(group=self.group, admin=True)
-        self.member = self.new_client(group=self.group, admin=False)
+        self.owner = self.new_client(group=self.group, owner=True)
+        self.member = self.new_client(group=self.group, owner=False)
         self.from_perms = from_perms
         self.to_perms = to_perms
 

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -299,7 +299,7 @@ class TestDelete(lib.ITest):
                       omero.model.ImageI(iid, False))
 
         # log in as group owner:
-        client_o, owner = self.new_client_and_user(group=group, admin=True)
+        client_o, owner = self.new_client_and_user(group=group, owner=True)
         query_o = client_o.sf.getQueryService()
 
         handlers = list()

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -607,9 +607,9 @@ class TestIShare(lib.ITest):
         # Member of user1's group
         gmember = self.new_client(group=group)
         # Owner of user1's group
-        gowner = self.new_client(group=group, admin=True)
+        gowner = self.new_client(group=group, owner=True)
         # Admin of a different group
-        oowner = self.new_client(admin=True)
+        oowner = self.new_client(owner=True)
 
         # login as user1
         share1 = owner.sf.getShareService()

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -138,7 +138,7 @@ class TestPermissions(lib.ITest):
 
         uuid = self.uuid()
         group = self.new_group(perms="rw----")
-        client, user = self.new_client_and_user(group=group, admin=True)
+        client, user = self.new_client_and_user(group=group, owner=True)
         update = client.sf.getUpdateService()
 
         project = ProjectI()
@@ -957,7 +957,7 @@ class TestPermissionProjections(lib.ITest):
             return self._system_admin
         elif who == "group-owner":
             self._group_owner = self.new_client(
-                group=self._group, admin=True)
+                group=self._group, owner=True)
             return self._group_owner
         else:
             self._other[who] = self.new_client(group=self._group)

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -447,8 +447,8 @@ client.closeSession()
 
         # Make two users in a new group. Only one is an owner of the group
         grp = self.new_group()
-        clientU, userU = self.new_client_and_user(group=grp, admin=False)
-        clientA, userA = self.new_client_and_user(group=grp, admin=True)
+        clientU, userU = self.new_client_and_user(group=grp, owner=False)
+        clientA, userA = self.new_client_and_user(group=grp, owner=True)
 
         # Make both users admins
         admin = self.root.sf.getAdminService()

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -168,7 +168,7 @@ class TestSearch(lib.ITest):
             p = x.ljust(6, "-")
             g = self.new_group(perms=p)
             u = self.new_client(group=g)
-            a = self.new_client(group=g, admin=True)
+            a = self.new_client(group=g, owner=True)
 
             uuid = self.uuid().replace("-", "")
 

--- a/components/tools/OmeroPy/test/integration/test_thumbnailPerms.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbnailPerms.py
@@ -159,7 +159,7 @@ class TestThumbnailPerms(lib.ITest):
 
         # Create private group with two member and one image
         group = self.new_group(perms="rw__--")
-        owner = self.new_client(group=group, admin=True)  # Owner of group
+        owner = self.new_client(group=group, owner=True)  # Owner of group
         member = self.new_client(group=group)  # Member of group
         privateImage = self.createTestImage(session=member.sf)
         pId = privateImage.getPrimaryPixels().getId().getValue()
@@ -304,7 +304,7 @@ class TestThumbnailPerms(lib.ITest):
         these should be used unless requested otherwise.
         """
         group = self.new_group(perms="rwr---")
-        groupOwner = self.new_user(group=group, admin=True)
+        groupOwner = self.new_user(group=group, owner=True)
         owner = self.new_client(group=group)
         other = self.new_client(user=groupOwner, group=group)
 
@@ -358,7 +358,7 @@ class TestThumbnailPerms(lib.ITest):
             group = self.new_group(perms="rwr---")
             owner = self.new_client(group=group)
             if roles == "owner":
-                user = self.new_user(group=group, admin=True)
+                user = self.new_user(group=group, owner=True)
                 other = self.new_client(user=user, group=group)
             elif roles == "admin":
                 user = self.new_user(group=group, system=True)
@@ -367,7 +367,7 @@ class TestThumbnailPerms(lib.ITest):
             group = self.new_group(perms="rwra--")
             owner = self.new_client(group=group)
             if roles == "owner":
-                user = self.new_user(group=group, admin=True)
+                user = self.new_user(group=group, owner=True)
                 other = self.new_client(user=user, group=group)
             elif roles == "admin":
                 user = self.new_user(group=group, system=True)
@@ -461,7 +461,7 @@ class TestThumbnailPerms(lib.ITest):
             group = self.new_group(perms="rwr---")
             owner = self.new_client(group=group)
             if roles == "owner":
-                user = self.new_user(group=group, admin=True)
+                user = self.new_user(group=group, owner=True)
                 other = self.new_client(user=user, group=group)
             elif roles == "admin":
                 user = self.new_user(group=group, system=True)
@@ -470,7 +470,7 @@ class TestThumbnailPerms(lib.ITest):
             group = self.new_group(perms="rwra--")
             owner = self.new_client(group=group)
             if roles == "owner":
-                user = self.new_user(group=group, admin=True)
+                user = self.new_user(group=group, owner=True)
                 other = self.new_client(user=user, group=group)
             elif roles == "admin":
                 user = self.new_user(group=group, system=True)
@@ -535,7 +535,7 @@ class TestThumbnailPerms(lib.ITest):
             group = self.new_group(perms="rwr---")
             owner = self.new_client(group=group)
             if roles == "owner":
-                user = self.new_user(group=group, admin=True)
+                user = self.new_user(group=group, owner=True)
                 other = self.new_client(user=user, group=group)
             elif roles == "admin":
                 user = self.new_user(group=group, system=True)
@@ -544,7 +544,7 @@ class TestThumbnailPerms(lib.ITest):
             group = self.new_group(perms="rwra--")
             owner = self.new_client(group=group)
             if roles == "owner":
-                user = self.new_user(group=group, admin=True)
+                user = self.new_user(group=group, owner=True)
                 other = self.new_client(user=user, group=group)
             elif roles == "admin":
                 user = self.new_user(group=group, system=True)


### PR DESCRIPTION
- adds integration tests (scenario for the new group sudo functionality)
- unify the usage of `owner=owner`in the `library.py` 
