### PR TITLE
Restrict download

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -163,6 +163,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.download.enabled">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!--  CLIENT PROPERTIES -->
     <bean class="ome.system.Preference" id="omero.client.scripts_to_ignore">
        <property name="db" value="false"/>

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -255,6 +255,8 @@ class login_required(object):
                 conn.getDropdownMenuSettings()
             request.session['server_settings']['email'] = \
                 conn.getEmailSettings()
+            request.session['server_settings']['download'] = \
+                conn.getDownloadSettings()
 
     def get_public_user_connector(self):
         """

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -116,6 +116,7 @@ class render_response(omeroweb.decorators.render_response):
         # UI server preferences
         if request.session.get('server_settings'):
             context['ome']['email'] =  request.session.get('server_settings').get('email', False)
+            context['ome']['download'] =  request.session.get('server_settings').get('download', False)
             if request.session.get('server_settings').get('ui'):
                 context.setdefault('ui', {})   # don't overwrite existing ui
                 context['ui']['orphans_name'] = request.session.get('server_settings').get('ui').get('orphans_name')

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/fileann.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/fileann.html
@@ -33,7 +33,7 @@
 {% if fileann.getFileName %}
 <li class="file_ann_wrapper" id="file_ann-{{ fileann.id }}"
         data-added-by="{{ added_by }}">
-    <a class='tooltip' href="{% url 'download_annotation' fileann.id %}">
+    <a class='tooltip' href="{% if fileann.canDownload %}{% url 'download_annotation' fileann.id %}{% else %}#{% endif %}">
         {{ fileann.getFileName|shortening:40 }}
 		<span>{% if fileann.getFileSize %}({{ fileann.getFileSize|default:0|filesizeformat }}){% endif %}</span>
     </a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -45,7 +45,7 @@
     <!-- This is used for 'batch annotate' panel with 'filesetCount'... -->
     <!-- ... and for single images -->
 
-    {% if image or filesetInfo %}
+    {% if image.canDownload or filesetInfo %}
     <!-- download options -->
     <div class="toolbar_dropdown">
         <button class="btn silver btn_download" title="Download Image as...">

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1937,6 +1937,22 @@ class OmeroWebSafeCallWrapper(OmeroGatewaySafeCallWrapper): #pragma: no cover
 
 omero.gateway.SafeCallWrapper = OmeroWebSafeCallWrapper
 
+
+class OmeroRestrictionWrapper (object):
+
+    def canDownload(self):
+        """
+        Determines if the current user can Download raw data linked to that
+        object. The canDownload() property is set on objects:
+        Image, Fileset, FileAnnotation as it is read from the server,
+        based on the current user, event context and group permissions.
+
+        :rtype:     Boolean
+        :return:    True if user can download.
+        """
+        return not self.getDetails().getPermissions().isRestricted('TEST')
+
+
 class OmeroWebObjectWrapper (object):
     
     annotation_counter = None
@@ -2214,7 +2230,7 @@ class DatasetWrapper (OmeroWebObjectWrapper, omero.gateway.DatasetWrapper):
      
 omero.gateway.DatasetWrapper = DatasetWrapper
 
-class ImageWrapper (OmeroWebObjectWrapper, omero.gateway.ImageWrapper):
+class ImageWrapper (OmeroWebObjectWrapper, OmeroRestrictionWrapper, omero.gateway.ImageWrapper):
     """
     omero_model_ImageI class wrapper overwrite omero.gateway.ImageWrapper
     and extends OmeroWebObjectWrapper.
@@ -2361,6 +2377,13 @@ class ScreenWrapper (OmeroWebObjectWrapper, omero.gateway.ScreenWrapper):
         super(ScreenWrapper, self).__prepare__(**kwargs)
         if kwargs.has_key('annotation_counter'):
             self.annotation_counter = kwargs['annotation_counter']
+
+class FileAnnotationWrapper (OmeroRestrictionWrapper, omero.gateway.FileAnnotationWrapper):
+    """
+    omero_model_FileAnnotationI class wrapper extends AnnotationWrapper.
+    """
+    pass
+
 
 omero.gateway.ScreenWrapper = ScreenWrapper
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -190,6 +190,9 @@ class OmeroWebGateway (omero.gateway.BlitzGateway):
                 .getConfigValue("omero.client.ui.menu.dropdown.everyone")
         return dropdown_menu
 
+    def getDownloadSettings(self):
+        return toBoolean(self.getConfigService().getConfigValue("omero.download.enabled"))
+
     ##############################################
     ##   IAdmin                                 ##
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -671,6 +671,9 @@ omero.client.ui.menu.dropdown.everyone=All Members
 # Flag to show/hide all users.
 omero.client.ui.menu.dropdown.everyone.enabled=true
 
+# Flag to show/hide download button.
+omero.download.enabled=true
+
 #############################################
 ## Ice overrides
 ##


### PR DESCRIPTION
As discussed this includes:
- client changes to validate if certain object can download Raw data,
- new property omero.download.enabled.

One thing what is missed on the client side is download button on batch annotation. `getFilesetFilesInfo` https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/src/omero/gateway/__init__.py#L2790 and `getArchivedFilesInfo` https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/src/omero/gateway/__init__.py#L2826 determin information displayed on batch annotation form. I think would be enough to test if at least one fileset has restriction. If so then we could add global flag in the returned dictionary.

I hope that make sense
