### PR TITLE
resolving download UI issues

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -203,6 +203,23 @@ class BaseContainer(BaseController):
         elif self.acquisition:
             return self.acquisition._obj.plate.id.val
 
+    def canDownload(self, objDict=None):
+        """
+        Returns False if any of selected object cannot be downloaded
+        """
+        # As used in batch_annotate panel
+        if objDict is not None:
+            for key in objDict:
+                for o in objDict[key]:
+                    if hasattr(o, 'canDownload'):
+                        if not o.canDownload():
+                            return False
+            return True
+        # As used in metadata_general panel
+        else:
+            return self.image.canDownload() or \
+                self.well.canDownload() or self.plate.canDonwload()
+
     def listFigureScripts(self, objDict=None):
         """
         This configures all the Figure Scripts, setting their enabled status

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -45,13 +45,14 @@
     <!-- This is used for 'batch annotate' panel with 'filesetCount'... -->
     <!-- ... and for single images -->
 
-    {% if image.canDownload or manager.well.canDownload or filesetInfo %}
+    {% if image or filesetInfo %}
     <!-- download options -->
     <div class="toolbar_dropdown">
         <button class="btn silver btn_download" title="Download Image as...">
             <span></span>
         </button>
         <ul class="dropdown">
+            {% if canDownload %}
             <!-- Here we handle a single image (in metadata general) - see below for multiple images (batch annotate) -->
             {% if image.getImportedFilesInfo.count %}
               {% with filesetInfo=image.getImportedFilesInfo %}
@@ -117,7 +118,8 @@
             </li>
             <li>{{ manager.}}
             {% endif %}
-
+            {% endif %}
+            
             {% if image %}
               <li>
                 <a href="{% url 'web_render_image_download' image.id %}" title="Download as JPEG">
@@ -162,7 +164,6 @@
         <span></span>
       </button>
     {% endif %}
-
 
       <button id="show_image_hierarchy" class="btn silver btn_hierarchy" title="Show parent Projects & Datasets">
         <span></span>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -566,7 +566,7 @@
            
             {% if manager.image %}            
 
-            {% with image=manager.image %}
+            {% with image=manager.image canDownload=manager.image.canDownload %}
                 {% include "webclient/annotations/includes/toolbar.html" %}
             {% endwith %}
 
@@ -668,7 +668,7 @@
             
             {% if manager.well %}            
 
-            {% with image=manager.well.getWellSample.image omeTiffDisabled=True %}
+            {% with image=manager.well.getWellSample.image canDownload=manager.well.canDownload omeTiffDisabled=True %}
                 {% include "webclient/annotations/includes/toolbar.html" %}
             {% endwith %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1337,6 +1337,7 @@ def batch_annotate(request, conn=None, **kwargs):
     if len(groupIds) > 1:
         context['annotationBlocked'] = "Can't add annotations because objects are in different groups"
         context['differentGroups'] = True       # E.g. don't run scripts etc
+    context['canDownload'] = manager.canDownload(objs)
     context['template'] = "webclient/annotations/batch_annotate.html"
     context['webclient_path'] = request.build_absolute_uri(reverse('webindex'))
     return context

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2499,6 +2499,10 @@ class WellWrapper(OmeroWebObjectWrapper, omero.gateway.WellWrapper):
         if 'link' in kwargs:
             self.link = 'link' in kwargs and kwargs['link'] or None
 
+    def canDownload(self):
+        return False
+
+
 omero.gateway.WellWrapper = WellWrapper
 
 


### PR DESCRIPTION
that should resolve all issues with download restrictions in web UI. please note there is hack in  `components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.canDownload` that must be removed once server has an option to turn of plate download and `well.canDownload` or `plate.canDownload` will return false. I hope that make sense
