### PR TITLE
Add minimal logic to parse psql profile file properties

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -379,6 +379,9 @@ class PrefsControl(WriteableConfigControl):
         from omero.install.config_parser import PropertyParser
         pp = PropertyParser()
         pp.parse_file(str(cfg.abspath()))
+        if not args.file:
+            psql_file = self.dir / "etc" / "profiles" / "psql"
+            pp.parse_file(str(psql_file.abspath()))
         if not args.no_web:
             pp.parse_module('omeroweb.settings')
         if args.headers:

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -379,11 +379,19 @@ class PrefsControl(WriteableConfigControl):
         from omero.install.config_parser import PropertyParser
         pp = PropertyParser()
         pp.parse_file(str(cfg.abspath()))
-        if not args.file:
-            psql_file = self.dir / "etc" / "profiles" / "psql"
-            pp.parse_file(str(psql_file.abspath()))
+
+        # Parse PSQL profile file
+        for p in pp:
+            if p.key == "omero.db.profile":
+                psql_file = self.dir / "etc" / "profiles" / p.val
+                pp.parse_file(str(psql_file.abspath()))
+                break
+
+        # Parse OMERO.web configuration properties
         if not args.no_web:
             pp.parse_module('omeroweb.settings')
+
+        # Display options
         if args.headers:
             pp.print_headers()
         elif args.keys:

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -19,9 +19,16 @@
 omero.data.dir=/OMERO/
 omero.managed.dir=${omero.data.dir}/ManagedRepository
 
+# The host name of the machine on which the PostgreSQL server is running
 omero.db.host=localhost
+
+# The name of the PostgreSQL database
 omero.db.name=omero
+
+# The username to use to connect to the PostgreSQL database
 omero.db.user=omero
+
+# The password to use to connect to the PostgreSQL database
 omero.db.pass=omero
 
 # Version of the database which is in use. This

--- a/etc/profiles/psql
+++ b/etc/profiles/psql
@@ -5,6 +5,7 @@
 # The TCP port or the local Unix-domain socket file extension on which the
 # server is listening for connections.
 omero.db.port=5432
+### END
 omero.db.driver=org.postgresql.Driver
 omero.db.driver_type=UNUSED
 omero.db.dialect=ome.util.PostgresqlDialect

--- a/etc/profiles/psql
+++ b/etc/profiles/psql
@@ -1,6 +1,9 @@
-#
-# postgres profile
-#
+##
+## postgres profile
+##
+
+# The TCP port or the local Unix-domain socket file extension on which the
+# server is listening for connections.
 omero.db.port=5432
 omero.db.driver=org.postgresql.Driver
 omero.db.driver_type=UNUSED


### PR DESCRIPTION
Minimal set of changes required to parse the properties in the `psql` profile file tin he same way that `omero.properties` is parsed.

Couple of additional questions:
- [x] should the file parsing be conditional to the value of `omero.db.profile`?
- [x] should we exclude some properties, tpyically `omero.db.driver_type=UNUSED`
